### PR TITLE
current HOTM, Musketeers and Season of Love corrections

### DIFF
--- a/data/families/69-musketeer.yml
+++ b/data/families/69-musketeer.yml
@@ -4,7 +4,7 @@ description: Brave Musketeers
 image: https://i.imgur.com/n63AlFO.png
 bonus:
   - "Bonus for 1/2/3 Heroes:"
-  - "50%/75%/100% chance to give Cover to a random ally for 6 turns when this character casts their Special Skill."
-  - "While in Cover, the ally takes no damage from Special Skill attacks or normal attacks. This character takes 90% / 70% / 70% of the damage that would by received by the character in Cover."
+  - "50%/75%/100% chance to give Cover to a random ally for 3 turns when this character casts their Special Skill."
+  - "While in Cover, the ally takes no damage from Special Skill attacks or normal attacks. This character takes 60% / 50% / 40% of the damage that would by received by the character in Cover."
   - "This effect can’t be dispelled, but ends when this character is defeated. Characters can only give cover to one ally at a time."
   - "The members of this family have additional perks in the Brave Musketeers event."

--- a/data/heroes/blue/3/Planchet.yml
+++ b/data/heroes/blue/3/Planchet.yml
@@ -1,6 +1,6 @@
 name: Planchet
 source: Musketeer
-class: Rogue
+class: Fighter
 family: Musketeer
 speed: Fast
 power: 486
@@ -9,9 +9,9 @@ defense: 453
 health: 811
 skill: Piercing Practice Slash
 effects:
-  - Destoys all Minions from the target.
-  - Deals 350% damage to the target.
-  - The caster regenerates 180 HP over 3 turns.
+  - Destroys all Minions from the target.
+  - Deals 385% damage to the target.
+  - The caster regenerates 243 HP over 3 turns.
 types:
   - Minion Destroyer
   - Hit 1
@@ -19,6 +19,6 @@ types:
 passives:
   - >-
     When this character receives damage from Special Skills or in place of a
-    character in Cover, there’s a 60% chance of deal 25% of the received damage
+    character in Cover, there’s a 60% chance of deal 20% of the received damage
     on all enemies.
 image: https://i.imgur.com/Hw45iGe.jpg

--- a/data/heroes/blue/5/Himeros.yml
+++ b/data/heroes/blue/5/Himeros.yml
@@ -1,6 +1,6 @@
 name: Himeros
 class: Rogue
-source: Love
+source: love
 family: Cupid
 speed: Very Fast
 power: 841

--- a/data/heroes/blue/5/Milady de Winter.yml
+++ b/data/heroes/blue/5/Milady de Winter.yml
@@ -22,6 +22,6 @@ types:
 passives:
   - >-
     When this character receives damage from Special Skills or in place of a
-    character in Cover, there’s a 60% chance of deal 25% of the received damage
+    character in Cover, there’s a 60% chance of deal 20% of the received damage
     on all enemies.
 image: https://i.imgur.com/NEdggUL.jpg

--- a/data/heroes/blue/5/Porthos.yml
+++ b/data/heroes/blue/5/Porthos.yml
@@ -3,7 +3,7 @@ source: Musketeer
 class: Barbarian
 family: Musketeer
 speed: Slow
-power: 840
+power: 841
 attack: 819
 defense: 793
 health: 1485
@@ -12,11 +12,11 @@ effects:
   - Deals 380% damage to all enemies.
   - >-
     Alters the power of all Ice shields on the board. When an attacking Hero
-    casts the special, the shields become enchanced with +74% attack. When a
-    defending Hero casts the special, the shields become weakened with -67%
+    casts the special, the shields become enchanced with +64% attack. When a
+    defending Hero casts the special, the shields become weakened with -57%
     attack.
+  - The caster regenerates 918 HP over 6 turns.
   - Deals extra damage against Fire.
-  - Caster regenerates 918 HP over 6 turns.
 types:
   - Hit All
   - Tile Enhancer

--- a/data/heroes/green/3/Zarola.yml
+++ b/data/heroes/green/3/Zarola.yml
@@ -2,7 +2,7 @@ name: Zarola
 class: Ranger
 speed: Fast
 family: Cupid
-source: Love
+source: love
 power: 486
 attack: 547
 defense: 474

--- a/data/heroes/green/4/Villiers.yml
+++ b/data/heroes/green/4/Villiers.yml
@@ -11,15 +11,15 @@ skill: The Duke's Investigation
 effects:
   - Deals 165% damage to the target and nearby enemies.
   - >-
-    Summon a Spy Fiend for all enemies. The Fiend damages the enemy with 45%
+    Summon a Spy Fiend for the target and nearby enemies. The Fiend damages the enemy with 45%
     attack every turn.
   - >-
     The Spy Fiend absorbs healing and disappears when it has absorbed health
-    equal to 30% of its target’s max health.
+    equal to 30% of its owner’s max health.
   - >-
     At the end of each turn, the Spy Fiend steals one of its target’s
     dispellable buffs and gives it to one character on the opposite team.
-  - Caster regenerates 324 HP over 4 turns.
+  - The caster regenerates 324 HP over 4 turns.
 types:
   - Hit 3
   - Fiend

--- a/data/heroes/green/5/Athos.yml
+++ b/data/heroes/green/5/Athos.yml
@@ -3,7 +3,7 @@ source: Musketeer
 class: Monk
 family: Musketeer
 speed: Very Fast
-power: 840
+power: 844
 attack: 846
 defense: 729
 health: 1565

--- a/data/heroes/green/5/Gregorion.yml
+++ b/data/heroes/green/5/Gregorion.yml
@@ -8,6 +8,7 @@ defense: 710
 health: 1351
 skill: Unwavering Focus
 effects:
+  - Deals 455% damage to the target.
   - All allies get +30% critical chance for 3 turns
   - >-
     Element Link gives all Nature allies +5% attack and +5% defense for 6 turns.

--- a/data/heroes/green/5/Queen Anne.yml
+++ b/data/heroes/green/5/Queen Anne.yml
@@ -3,7 +3,7 @@ source: Musketeer
 class: Cleric
 family: Musketeer
 speed: Slow
-power: 840
+power: 842
 attack: 708
 defense: 889
 health: 1580
@@ -12,9 +12,9 @@ effects:
   - >-
     The caster gets Taunt that prevents enemies from using Special Skills on the
     caster’s allies for 6 turns.
+  - The caster regenerates 918 HP over 6 turns.
   - All allies get +65% defense for 6 turns.
   - All allies get +44% mana generation for 6 turns.
-  - Caster regenerates 918 HP over 6 turns
 types:
   - Taunt
   - Defense Buff

--- a/data/heroes/purple/4/Kitty.yml
+++ b/data/heroes/purple/4/Kitty.yml
@@ -22,6 +22,6 @@ types:
 passives:
   - >-
     When this character receives damage from Special Skills or in place of a
-    character in Cover, there’s a 60% chance of deal 25% of the received damage
+    character in Cover, there’s a 60% chance of deal 20% of the received damage
     on all enemies.
 image: https://i.imgur.com/2nOJ3dV.jpg

--- a/data/heroes/purple/5/Aramis.yml
+++ b/data/heroes/purple/5/Aramis.yml
@@ -3,7 +3,7 @@ source: Musketeer
 class: Ranger
 family: Musketeer
 speed: Average
-power: 840
+power: 845
 attack: 873
 defense: 780
 health: 1402

--- a/data/heroes/purple/5/Phthonus.yml
+++ b/data/heroes/purple/5/Phthonus.yml
@@ -1,6 +1,6 @@
 name: Phthonus
 class: Wizard
-source: Love
+source: love
 family: Cupid
 speed: Slow
 power: 841

--- a/data/heroes/red/5/Cupido.yml
+++ b/data/heroes/red/5/Cupido.yml
@@ -1,6 +1,6 @@
 name: Cupido
 class: Ranger
-source: Love
+source: love
 family: Cupid
 speed: Average
 power: 842

--- a/data/heroes/red/5/D'Artagnan.yml
+++ b/data/heroes/red/5/D'Artagnan.yml
@@ -3,7 +3,7 @@ source: Musketeer
 class: Paladin
 family: Musketeer
 speed: Fast
-power: 840
+power: 843
 attack: 834
 defense: 801
 health: 1446

--- a/data/heroes/yellow/3/Felton.yml
+++ b/data/heroes/yellow/3/Felton.yml
@@ -7,7 +7,7 @@ power: 486
 attack: 537
 defense: 510
 health: 648
-skill: Covert Stab
+skill: Remorseless Stab
 effects:
   - Deals 355% damage to the target.
   - Deals 100 extra damage if the target has boosted health.
@@ -21,6 +21,6 @@ types:
 passives:
   - >-
     When this character receives damage from Special Skills or in place of a
-    character in Cover, there’s a 60% chance of deal 25% of the received damage
+    character in Cover, there’s a 60% chance of deal 20% of the received damage
     on all enemies.
 image: https://i.imgur.com/KO2VqaC.jpg

--- a/data/heroes/yellow/4/Voluptas.yml
+++ b/data/heroes/yellow/4/Voluptas.yml
@@ -1,6 +1,6 @@
 name: Voluptas
 class: Druid
-source: Love
+source: love
 speed: Average
 power: 686
 attack: 650
@@ -9,7 +9,7 @@ health: 1387
 skill: Flat Cake for Sweethearts
 effects:
   - Destroys all Fiends from the caster and nearby allies.
-  - Recovers 40% heath for the caster and nearby allies.
+  - Recovers 40% health for the caster and nearby allies.
 types:
   - Fiend Destroyer
   - Healer

--- a/data/heroes/yellow/5/Gilligan.yml
+++ b/data/heroes/yellow/5/Gilligan.yml
@@ -9,8 +9,9 @@ defense: 760
 health: 1528
 skill: Reckless Charge
 effects:
-  - Deals 300% damage to the target and minor damage to nearby enemies.
-  - All allies get +44% defense against Dark for 4 turns.
+  - Deals 300% damage to the target and nearby enemies.
+  - The attack has a 60% chance to bypass defensive buffs. This includes counterattacks.
+  - All allies get +35% defense for 4 turns.
   - >-
     Element Link gives all Holy allies a +5% chance to dodge status ailments for
     4 turns. This effect cannot be dispelled.
@@ -19,7 +20,7 @@ types:
   - Defense Buff
 passives:
   - >-
-    Mana Per Enemy Buff - Gains small amount of mana for every status effect
+    Mana Per Enemy Buff - Gains a small amount of mana for every active status effect
     buff that the enemy team has at the start of each turn (maximum of 20
     buffs).
   - >-


### PR DESCRIPTION
I am not sure about changes to Season of Love heroes. On site, the heroes source appears to be HotM (default?), so I tried to lower the source key to love (I also found Loahu in my heroes list, but I will try to correct heroes when their portal is active in game, to be official).