### PR TITLE
new speed for Slayer family heroes

### DIFF
--- a/data/speeds.yml
+++ b/data/speeds.yml
@@ -78,3 +78,12 @@ speeds:
       13:
         - 5
         - 11
+  slayer:
+    key: slayer
+    code: 8
+    shortName: SL
+    Description: Slayer
+    Tiles: [11]
+    breakPoints:
+      10: [10]
+      22: [9]

--- a/data/speeds.yml
+++ b/data/speeds.yml
@@ -82,8 +82,8 @@ speeds:
     key: slayer
     code: 8
     shortName: SL
-    Description: Slayer
-    Tiles: [11]
+    description: Slayer
+    tiles: [11]
     breakPoints:
       10: [10]
       22: [9]


### PR DESCRIPTION
From in-game mana speed slayer description: Slayer mana speed is below average, but the mana generation speed of this Hero increases when the family effect activates.

PS: after you accept this new speed can we start using it for slayer family heroes, or you need to make some changes first?